### PR TITLE
feat: accept ExUnit context

### DIFF
--- a/lib/snapshy.ex
+++ b/lib/snapshy.ex
@@ -61,7 +61,7 @@ defmodule Snapshy do
 
   defmacro __using__(_options) do
     quote do
-      import Snapshy, only: [match_snapshot: 1, test_snapshot: 2]
+      import Snapshy, only: [match_snapshot: 1, test_snapshot: 2, test_snapshot: 3]
     end
   end
 
@@ -90,6 +90,17 @@ defmodule Snapshy do
   defmacro test_snapshot(name, do: expr) do
     quote do
       test unquote(name) do
+        match_snapshot(unquote(expr))
+      end
+    end
+  end
+
+  @doc """
+  Same as `Snashy.test_snapshot/2` but excepts a context.
+  """
+  defmacro test_snapshot(name, context, do: expr) do
+    quote do
+      test unquote(name), unquote(context) do
         match_snapshot(unquote(expr))
       end
     end

--- a/test/__snapshots__/unit/snapshy_test/test_test_snapshot_it_accepts_a_context.snap
+++ b/test/__snapshots__/unit/snapshy_test/test_test_snapshot_it_accepts_a_context.snap
@@ -1,13 +1,1 @@
-%{
-  async: false,
-  case: SnapshyTest,
-  describe: "test_snapshot",
-  describe_line: 27,
-  file: "/Users/john.wright/Workspace/snapshy/test/unit/snapshy_test.exs",
-  key: :value,
-  line: 32,
-  module: SnapshyTest,
-  registered: %{},
-  test: :"test test_snapshot it accepts a context",
-  test_type: :test
-}
+:value

--- a/test/__snapshots__/unit/snapshy_test/test_test_snapshot_it_accepts_a_context.snap
+++ b/test/__snapshots__/unit/snapshy_test/test_test_snapshot_it_accepts_a_context.snap
@@ -1,0 +1,13 @@
+%{
+  async: false,
+  case: SnapshyTest,
+  describe: "test_snapshot",
+  describe_line: 27,
+  file: "/Users/john.wright/Workspace/snapshy/test/unit/snapshy_test.exs",
+  key: :value,
+  line: 32,
+  module: SnapshyTest,
+  registered: %{},
+  test: :"test test_snapshot it accepts a context",
+  test_type: :test
+}

--- a/test/unit/snapshy_test.exs
+++ b/test/unit/snapshy_test.exs
@@ -23,4 +23,14 @@ defmodule SnapshyTest do
   test "it saves a file for custom structs" do
     match_snapshot(%Struct{key: "different_value"})
   end
+
+  describe "test_snapshot" do
+    setup do
+      [key: :value]
+    end
+
+    test_snapshot "it accepts a context", context do
+      context
+    end
+  end
 end

--- a/test/unit/snapshy_test.exs
+++ b/test/unit/snapshy_test.exs
@@ -30,7 +30,7 @@ defmodule SnapshyTest do
     end
 
     test_snapshot "it accepts a context", context do
-      context
+      context[:key]
     end
   end
 end


### PR DESCRIPTION
Adds `Snapshy.test_snapshot/3` so that `test_snapshot` can accept a context.

See #3.