### PR TITLE
Allow Inspect.Algebra.to_doc/2 Options To Be Overriden

### DIFF
--- a/lib/snapshy.ex
+++ b/lib/snapshy.ex
@@ -202,7 +202,8 @@ defmodule Snapshy do
     [
       limit: :infinity,
       printable_limit: :infinity,
-      pretty: true
+      pretty: true,
+      structs: false
     ]
   end
 

--- a/lib/snapshy.ex
+++ b/lib/snapshy.ex
@@ -179,11 +179,7 @@ defmodule Snapshy do
 
   defp serialize(value) do
     value
-    |> Inspect.Algebra.to_doc(%Inspect.Opts{
-      limit: :infinity,
-      printable_limit: :infinity,
-      pretty: true
-    })
+    |> Inspect.Algebra.to_doc(inspect_options())
     |> Inspect.Algebra.group()
     |> Inspect.Algebra.format(80)
     |> Enum.join()
@@ -193,6 +189,21 @@ defmodule Snapshy do
     {term, []} = Code.eval_string(value, [], __ENV__)
 
     term
+  end
+
+  defp inspect_options do
+    opts = default_inspect_options()
+      |> Keyword.merge(Application.get_env(:snapshy, :serialize_inspect_options, []))
+
+    struct(Inspect.Opts, opts)
+  end
+
+  defp default_inspect_options do
+    [
+      limit: :infinity,
+      printable_limit: :infinity,
+      pretty: true
+    ]
   end
 
   #############################################################################

--- a/test/unit/snapshy_test.exs
+++ b/test/unit/snapshy_test.exs
@@ -24,6 +24,63 @@ defmodule SnapshyTest do
     match_snapshot(%Struct{key: "different_value"})
   end
 
+  test "saved file can be evaluated for opaque structs when serialize structs option is false", %{test: test_name} do
+    snap_filename = snap_file_for_test(test_name)
+
+    assert File.exists?(snap_filename) == false
+
+    original_serialized_inspect_options = Application.get_env(:snapshy, :serialize_inspect_options)
+    Application.put_env(:snapshy, :serialize_inspect_options, [structs: false])
+
+    opaque_struct = %Struct{key: Version.parse!("1.2.3")}
+
+    match_snapshot(opaque_struct)
+
+    assert {:ok, serialized_value} = File.read(snap_filename)
+
+    assert {value, []} = Code.eval_string(serialized_value, [], __ENV__)
+
+    assert File.rm(snap_filename)
+
+    unless original_serialized_inspect_options do
+      Application.put_env(:snapshy, :serialize_inspect_options, original_serialized_inspect_options)
+    end
+  end
+
+  test "saved file cannot be evaluated for opaque structs when serialize structs option is true", %{test: test_name} do
+    snap_filename = snap_file_for_test(test_name)
+
+    assert File.exists?(snap_filename) == false
+
+    original_serialized_inspect_options = Application.get_env(:snapshy, :serialize_inspect_options)
+    Application.put_env(:snapshy, :serialize_inspect_options, [structs: true])
+
+    opaque_struct = %Struct{key: Version.parse!("1.2.3")}
+
+    match_snapshot(opaque_struct)
+
+    assert {:ok, serialized_value} = File.read(snap_filename)
+
+    assert_raise TokenMissingError, fn ->
+      assert {value, []} = Code.eval_string(serialized_value, [], __ENV__)
+    end
+
+    assert File.rm(snap_filename)
+
+    unless original_serialized_inspect_options do
+      Application.put_env(:snapshy, :serialize_inspect_options, original_serialized_inspect_options)
+    end
+  end
+
+  defp snap_file_for_test(test_name) do
+    [
+      "test/__snapshots__/unit/snapshy_test/",
+      Atom.to_string(test_name) |> String.replace(" ", "_"),
+      ".snap"
+    ]
+    |> Enum.join()
+  end
+
   describe "test_snapshot" do
     setup do
       [key: :value]


### PR DESCRIPTION
## PROBLEM

When serializing structs that are somehow opaque, like `Version` or `Money`, we found `Code.eval_string/3` to not be able to evaluate such kinds of serialized values using the current `%Inspect.Opts{}` values passed to the `Inspect.Algebra.to_doc/2` function:

Example:
```elixir
> struct = %{key: Version.parse!("1.2.3")}
%{key: #Version<1.2.3>}
> serialized_value = struct |> Inspect.Algebra.to_doc(%Inspect.Opts{limit: :infinity, printable_limit: :infinity, pretty: true}) |> Inspect.Algebra.group() |> Inspect.Algebra.format(80) |> Enum.join()
"%{key: #Version<1.2.3>}"
> Code.eval_string(serialized_value, [], __ENV__)
** (TokenMissingError) iex:20: missing terminator: } (for "{" starting at line 20)
```

## SOLUTION
We should improve how we pass the `%Inspect.Opts{}` to the `Inspect.Algebra.to_doc/2` so see can customize it by setting the `structs` param to be `false`. Now the structs won't be formatted by the inspect protocol but printed as regular maps. Notice the default value is `true`.

Thanks to this optional parameter, the serialized value will look as:
```elixir
"%{\n  key: %{__struct__: Version, build: nil, major: 1, minor: 2, patch: 3, pre: []}\n}"
```

instead of
```elixir
"%{key: #Version<1.2.3>}"
```

### TESTING

We found that following the `No` branch from the `Snap File Exists?` comparison is good enough to test the new functionality, as we need just to ensure how the struct is serialized at all.
```
                             ┌──────────────────────────────┐
                             │  match(actual_value, caller) │
                             └──────────────┬───────────────┘
                                            │
                                            │
                          NO       ┌────────▼──────────┐    YES
                 ┌─────────────────┤ snapfile_exists?  ├───────────────┐
                 │                 └───────────────────┘               │
                 │                                                     │
                 │                                                     │
   ┌─────────────▼──────────────┐                           ┌──────────▼────────┐
   │ create_empty_snapshot_file │                           │ get_snapshot(file)│
   └─────────────┬──────────────┘                           └──────────┬────────┘
                 │                                                     │
                 │                                                     │
┌────────────────▼──────────────────┐            ┌─────────────────────▼──────────────────────┐
│ save_snapshot(file, actual_value) │            │ assert(file, snapshot_value, actual_value) │
└────────────────┬──────────────────┘            └─────────────────────┬──────────────────────┘
                 │                                                     │
                 │                                                     │
               ┌─▼─┐                                     ┌─────────────▼─────────────────┐  YES      ┌───┐
               │:OK│                                     │ snapshot_value == actual_value├───────────►:OK│
               └───┘                                     └─────────────┬─────────────────┘           └───┘
                                                                       │NO
                                                                       │
                                                                  ┌────▼──────┐   MO                 ┌────────┐
                                                                  │ override? ├──────────────────────► :ERROR │
                                                                  └────┬──────┘                      └────────┘
                                                                       │
                                                                       │YES
                                                                       │
                                                         ┌─────────────▼───────────────────┐
                                                         │save_snapshot(file, actual_value)│
                                                         └─────────────┬───────────────────┘
                                                                       │
                                                                       │
                                                                      ┌▼──┐
                                                                      │:OK│
                                                                      └───┘
```