### PR TITLE
Allow specification of snapshot location

### DIFF
--- a/test/some_env/__snapshots__/unit/snapshy_test/test_saves_snapshot_in_specified_directory.snap
+++ b/test/some_env/__snapshots__/unit/snapshy_test/test_saves_snapshot_in_specified_directory.snap
@@ -1,0 +1,1 @@
+%{__struct__: Struct, key: "value"}

--- a/test/unit/snapshy_test.exs
+++ b/test/unit/snapshy_test.exs
@@ -87,3 +87,12 @@ defmodule SnapshyTest do
     end
   end
 end
+
+defmodule SnapshyDirectoryTest do
+  use Snapshy, snapshot_location: "test/some_env/__snapshots__"
+  use ExUnit.Case
+
+  test "saves snapshot in specified directory" do
+    match_snapshot(%Struct{})
+  end
+end


### PR DESCRIPTION
Hello!

I've recently come across a situation where this library would be perfect for building an end to end test image for some of my backend services. I need to be able to choose the snapshot for the specific environment as the values in the end to end test differ across deployment environments.

This change allows for arbitrary changing of where the snapshots will be stored. In my case it will allow me to switch snapshot selection to the correct environment.

I realise I could probably work around this instead and have some ExUnit hooks which move the files around to compare, but this felt like a nice addition anyway.

Please let me know if you think there is something that can be improved upon, or whether it's not something you can work with.

Please note that when I ran this locally, one of the tests was already failing, so I have ignored it. The test I have added should be green.