### PR TITLE
Allows custom format width

### DIFF
--- a/lib/snapshy.ex
+++ b/lib/snapshy.ex
@@ -184,14 +184,17 @@ defmodule Snapshy do
     value
     |> Inspect.Algebra.to_doc(inspect_options())
     |> Inspect.Algebra.group()
-    |> Inspect.Algebra.format(80)
-    |> Enum.join()
+    |> Inspect.Algebra.format(format_width_option())
   end
 
   defp deserialize(value) do
     {term, []} = Code.eval_string(value, [], __ENV__)
 
     term
+  end
+
+  defp format_width_option() do
+    Application.get_env(:snapshy, :format_width, 80)
   end
 
   defp inspect_options do


### PR DESCRIPTION
Hi, 

Thank you for making this library. It help me and my team save testing time a lot. ❤️ 

I create this patch to custom format line width. The previous one is fixed to only `80`.

## Why is it matter

In my daily work, I have csv table like data structure (list of list) to test in unit test, columns quite a lot, and current snapshot format width make it hard to read (but it's better than asserting in unit test!). 

Comparing width at 80 vs 500: 

80

<img width="886" alt="Screenshot 2566-09-15 at 10 26 19" src="https://github.com/DCzajkowski/snapshy/assets/484530/d7dcd22e-fe6e-47e0-9441-8e62e936d3c3">

500

<img width="1879" alt="Screenshot 2566-09-15 at 10 09 42" src="https://github.com/DCzajkowski/snapshy/assets/484530/b5529319-25e4-4b81-ac53-35418947f6e6">

